### PR TITLE
Allow repository.type to override autodetect type

### DIFF
--- a/packages/conventional-changelog-core/lib/merge-config.js
+++ b/packages/conventional-changelog-core/lib/merge-config.js
@@ -198,7 +198,9 @@ function mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts
       if (context.host && (!context.issue || !context.commit || !parserOpts || !parserOpts.referenceActions)) {
         var type;
 
-        if (context.host) {
+        if (context.type) {
+          type = context.type
+        } else if (context.host) {
           var match = context.host.match(rhosts);
           if (match) {
             type = match[0];


### PR DESCRIPTION
I suspect this will allow you to do this syntax for privately hosted gitlab/github/bitbucket:

```
"repository": {
  "url": "https://private.gitlab",
  "type": "gitlab"
}
```